### PR TITLE
Anonymous OOC, Who and Adminwho

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -38,7 +38,7 @@
 
 	log_ooc("[mob.name]/[key] : [msg]")
 
-	var/keyname = key
+	var/keyname = anonymous_key
 	if(prefs.unlock_content)
 		if(prefs.toggles & MEMBER_PUBLIC)
 			keyname = "<font color='[prefs.ooccolor]'><img style='width:9px;height:9px;' class=icon src=\ref['icons/member_content.dmi'] iconstate=blag>[keyname]</font>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -10,7 +10,7 @@
 	if(holder)
 		if(check_rights(R_ADMIN,0))//If they have +ADMIN, show hidden admins, player IC names and IC status
 			for(var/client/C in clients)
-				var/entry = "\t[C.key]"
+				var/entry = "\t[C.anonymous_key]"
 				if(C.holder && C.holder.fakekey)
 					entry += " <i>(as [C.holder.fakekey])</i>"
 				entry += " - Playing as [C.mob.real_name]"
@@ -32,7 +32,7 @@
 				Lines += entry
 		else//If they don't have +ADMIN, only show hidden admins
 			for(var/client/C in clients)
-				var/entry = "\t[C.key]"
+				var/entry = "\t[C.anonymous_key]"
 				if(C.holder && C.holder.fakekey)
 					entry += " <i>(as [C.holder.fakekey])</i>"
 				Lines += entry
@@ -41,7 +41,7 @@
 			if(C.holder && C.holder.fakekey)
 				Lines += C.holder.fakekey
 			else
-				Lines += C.key
+				Lines += C.anonymous_key
 
 	for(var/line in sortList(Lines))
 		msg += "[line]\n"
@@ -74,6 +74,6 @@
 	else
 		for(var/client/C in admins)
 			if(!C.holder.fakekey)
-				msg += "\t[C] is a [C.holder.rank]\n"
+				msg += "\t[C.anonymous_key] is a [C.holder.rank]\n"
 
 	src << msg

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -16,6 +16,8 @@
 	var/moving			= null
 	var/adminobs		= null
 	var/area			= null
+	
+	var/anonymous_key = ""  //A key given to everyone for anonymous OOC
 
 		///////////////
 		//SOUND STUFF//

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -164,9 +164,9 @@ var/next_external_rsc = 0
 		sync_client_with_db()
 
 	send_resources()
-	
+
 	var/rand_number = rand(1, 1000)
-    anonymous_key = "Anonymous #[rand_number]"
+	anonymous_key = "Anonymous #[rand_number]"
 
 	if(!void)
 		void = new()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -164,6 +164,9 @@ var/next_external_rsc = 0
 		sync_client_with_db()
 
 	send_resources()
+	
+	var/rand_number = rand(1, 1000)
+    anonymous_key = "Anonymous #[rand_number]"
 
 	if(!void)
 		void = new()


### PR DESCRIPTION
It makes it so everyone gets a "Anon#[number]" not unlike Aliens, Slimes and Golems. Whenever you use any of those commands, you'll see that name instead of their CKey.

Admins see the exact same thing but since there's still Player Panel or Inspect Vars and everyone still keeps their CVar on their client, you can still moderate, ban or warn people as usual.